### PR TITLE
update shebang to work on more environments

### DIFF
--- a/zws
+++ b/zws
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ZWS0=$'\u200b'
 ZWS1=$'\u200c'


### PR DESCRIPTION
shebang が /bin/bash 決め打ちになっていますが、/usr/bin/env  を使うことでより多くの環境で
実行できるようになると思います。

以下、補足情報です。

手元のmacOS環境では、Homebrew で新しいbashとgnu-sedをインストールして、shebang の
修正をすることで動作するようになりました。

1. macOS の /bin/bash は古すぎてうまく動作しませんでした。'\u' のサポートが 4.2 移行のため

```
$ /bin/bash --version
GNU bash, version 3.2.57(1)-release (x86_64-apple-darwin18)
Copyright (C) 2007 Free Software Foundation, Inc.
```

Homebrew で新しいバージョンをインストールしていましたが、shebang に /bin/bash とパスが
決め打ちになっているため、対処前は bash /usr/local/bin/zws として実行する必要がありました。

```
$ which bash
/usr/local/bin/bash
$ bash --version
GNU bash, バージョン 5.0.2(1)-release (x86_64-apple-darwin17.7.0)
Copyright (C) 2019 Free Software Foundation, Inc.
ライセンス GPLv3+: GNU GPL バージョン 3 またはそれ以降 <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
```

2. macOS /usr/bin/sed は BSD sed で -z オプションをサポートしておらず、gnu-sed の
インストールが必要でした。(今回送付するパッチとは無関係ですが、動作報告＆参考情報
として書いておきます)

```
$ which sed
/usr/local/opt/gnu-sed/libexec/gnubin/sed
$ sed --version
sed (GNU sed) 4.5
Copyright (C) 2018 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Jay Fenlason, Tom Lord, Ken Pizzini,
and Paolo Bonzini.
GNU sed home page: <https://www.gnu.org/software/sed/>.
General help using GNU software: <https://www.gnu.org/gethelp/>.
E-mail bug reports to: <bug-sed@gnu.org>.
```
